### PR TITLE
feat: add ox support for item data

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -97,12 +97,12 @@ RegisterNetEvent('jim-consumables:Consume', function(itemName)
 	if Config.Debug then print("^5Debug^7: ^3Consume^7: ^2Player Movement Type^7 - ^6"..json.encode(MovementType).." ^7") end
     if Config.UseProgbar then
         if Config.ProgressBar == "ox" then
-            CreateThread(function() if exports.ox_lib:progressBar({ duration = time, label = string..QBCore.Shared.Items[itemName].label.."..", useWhileDead = false, canCancel = false,}) then consuming = false else end end)
+            CreateThread(function() if exports.ox_lib:progressBar({ duration = time, label = string..(Config.Inv == "ox" and exports.ox_inventory:Items(itemName).label or QBCore.Shared.Items[itemName].label).."..", useWhileDead = false, canCancel = false,}) then consuming = false else end end)
         else
-            CreateThread(function() QBCore.Functions.Progressbar('jimmy_consume_', string..QBCore.Shared.Items[itemName].label.."..", time, false, false, {disableMovement = false, disableCarMovement = false, disableMouse = false, disableCombat = true,}, {}, {}, {}, function() consuming = false end, function() end, itemName) end)
+            CreateThread(function() QBCore.Functions.Progressbar('jimmy_consume_', string..(Config.Inv == "ox" and exports.ox_inventory:Items(itemName).label or QBCore.Shared.Items[itemName].label).."..", time, false, false, {disableMovement = false, disableCarMovement = false, disableMouse = false, disableCombat = true,}, {}, {}, {}, function() consuming = false end, function() end, itemName) end)
         end
     else
-        triggerNotify(nil, string..QBCore.Shared.Items[itemName].label.."..", "success")
+        triggerNotify(nil, string..(Config.Inv == "ox" and exports.ox_inventory:Items(itemName).label or QBCore.Shared.Items[itemName].label).."..", "success")
     end
 
 	consuming = true

--- a/server/server.lua
+++ b/server/server.lua
@@ -28,18 +28,18 @@ RegisterNetEvent('jim-consumables:server:toggleItem', function(give, item, amoun
 					QBCore.Functions.GetPlayer(src).Functions.RemoveItem(item, 1)
 					remamount -= 1
 				end
-				TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[item], "remove", amount) -- Show removal item box when all are removed
+				TriggerClientEvent('inventory:client:ItemBox', src, (Config.Inv == "ox" and exports.ox_inventory:Items(item) or QBCore.Shared.Items[item]), "remove", amount) -- Show removal item box when all are removed
 				return
 			end
 			if QBCore.Functions.GetPlayer(src).Functions.RemoveItem(item, amount) then
-				if Config.Debug then print("^5Debug^7: ^1Removing ^2from Player^7(^2"..src.."^7) '^6"..QBCore.Shared.Items[item].label.."^7(^2x^6"..(amount or "1").."^7)'") end
-				TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[item], "remove", amount)
+				if Config.Debug then print("^5Debug^7: ^1Removing ^2from Player^7(^2"..src.."^7) '^6"..(Config.Inv == "ox" and exports.ox_inventory:Items(item).label or QBCore.Shared.Items[itemName].label).."^7(^2x^6"..(amount or "1").."^7)'") end
+				TriggerClientEvent('inventory:client:ItemBox', src, (Config.Inv == "ox" and exports.ox_inventory:Items(item) or QBCore.Shared.Items[item]), "remove", amount)
 			end
 		else TriggerEvent("jim-consumables:server:DupeWarn", item, src) end -- if not boot the player
 	elseif give then
 		if QBCore.Functions.GetPlayer(src).Functions.AddItem(item, amount) then
-			if Config.Debug then print("^5Debug^7: ^4Giving ^2Player^7(^2"..src.."^7) '^6"..QBCore.Shared.Items[item].label.."^7(^2x^6"..(amount or "1").."^7)'") end
-			TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items[item], "add", amount)
+			if Config.Debug then print("^5Debug^7: ^4Giving ^2Player^7(^2"..src.."^7) '^6"..(Config.Inv == "ox" and exports.ox_inventory:Items(item).label or QBCore.Shared.Items[itemName].label).."^7(^2x^6"..(amount or "1").."^7)'") end
+			TriggerClientEvent('inventory:client:ItemBox', src, (Config.Inv == "ox" and exports.ox_inventory:Items(item) or QBCore.Shared.Items[item]), "add", amount)
 		end
 	end
 end)


### PR DESCRIPTION
Currently when you add items to the config, it requires them to be in qbcore/shared/items.lua, while I imagine most people will be running ox_inventory instead of qb-inventory this causes issues with people who just want to run an ox setup, as this means every single item we want to use needs to be put in both qbcore/shared/items.lua and ox_inventory/data/items.lua, instead of just one.

Hopefully this fixes it, at least it does for ox (I tested it on my server), if you'd prefer a different approach I'd be glad to do it, but I thought this was slightly cleaner then a bunch of if statements. Untested on qb-inventory though as we don't use that, but I can't see why it wouldn't work.

I think with this and a few other hardlined qbcore checks being changed this script would be compatible with both esx and qbcore , which I might do when I work on my esx server if there is interest in adding compatability here